### PR TITLE
Bestlearner fix 

### DIFF
--- a/src/pipelines.jl
+++ b/src/pipelines.jl
@@ -190,8 +190,8 @@ function processexpr(args)
       args[ndx] = :Pipeline
     elseif args[ndx] == :+
       args[ndx] = :ComboPipeline
-    elseif args[ndx] == :|
-      args[ndx] = :VoteEnsemble
+    elseif args[ndx] == :*
+      args[ndx] = :BestLearner
     end
   end
   return args

--- a/test/test_pipeline.jl
+++ b/test/test_pipeline.jl
@@ -56,7 +56,7 @@ function test_pipeline()
   pt = PrunedTree()
   pcombo3 = @pipeline disc |> ((catf + numf) + (numf |> pca) + (numf |> ica) + (catf|>ohe)) |> rf
   (fit_transform!(pcombo3,X,Y)  .== Y) |> sum == 150
-  pcombo4 = @pipeline (numf |> pca) + (numf |> ica) |> (ada | rf | pt)
+  pcombo4 = @pipeline (numf |> pca) + (numf |> ica) |> (ada * rf * pt)
   @test crossvalidate(pcombo4,X,Y).mean >= 0.90
 end
 @testset "Pipelines" begin


### PR DESCRIPTION
- use of `*` instead of `|` to avoid recursive call instead of just one call.