### PR TITLE
fix deprecated warnings

### DIFF
--- a/docs/src/tutorial/preprocessing.md
+++ b/docs/src/tutorial/preprocessing.md
@@ -38,7 +38,7 @@ can be categorical and should be hot-bit encoded. One way to verify is
 to compute the number of unique instances for each column and look for 
 columns with relatively smaller count:
 ```@repl preprocessing
-[n=>length(unique(x)) for (n,x) in pairs(eachcol(df))] |> collect
+[n=>length(unique(x)) for (n,x) in pairs(eachcol(diabetesdf))] |> collect
 ```
 
 Among the input columns, `preg` has only 17 unique instances and it can

--- a/docs/src/tutorial/preprocessing.md
+++ b/docs/src/tutorial/preprocessing.md
@@ -38,7 +38,7 @@ can be categorical and should be hot-bit encoded. One way to verify is
 to compute the number of unique instances for each column and look for 
 columns with relatively smaller count:
 ```@repl preprocessing
-[n=>length(unique(x)) for (n,x) in eachcol(diabetesdf,true)] |> collect
+[n=>length(unique(x)) for (n,x) in pairs(eachcol(df))] |> collect
 ```
 
 Among the input columns, `preg` has only 17 unique instances and it can


### PR DESCRIPTION
I have fixed the warnings in the tutorial. [Link to issue](https://github.com/IBM/AutoMLPipeline.jl/issues/63)